### PR TITLE
Fix BoardLoss forward

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -23,8 +23,10 @@ class BoardLoss(nn.Module):
         
         # Constraints: no more than 2 suns or moons together
         batch_size = binary_output.shape[0]
-        [(self.cons_row(binary_output[n], loss, batch_size), self.cons_col)
-         for n in range(batch_size)]
+        for n in range(batch_size):
+            loss = self.cons_row(binary_output[n], loss, batch_size)
+            loss = self.cons_col(binary_output[n], loss, batch_size)
+
         return loss
 
 


### PR DESCRIPTION
## Summary
- remove unused list comprehension for board constraints
- call both `cons_row` and `cons_col` during `forward`

## Testing
- `python -m py_compile loss.py`
- `python - <<'PY'
import torch
from loss import BoardLoss
b = BoardLoss()
input=torch.rand(2,6,6)
loss=b(input)
print('loss',loss)
PY`

------
https://chatgpt.com/codex/tasks/task_b_684691eb09488328987315ee96322035