### PR TITLE
Fix opposite rule propagation in set_rule_random

### DIFF
--- a/core.py
+++ b/core.py
@@ -88,7 +88,7 @@ class TangoBoard:
         else:
             self.set_opp_rule(x, y, x_2, y_2)
             if (x, y) in self.fixed_cells:
-                new_fixed_cell = self.apply_equal_rule(x, y)
+                new_fixed_cell = self.apply_opp_rule(x, y)
 
         
         if new_fixed_cell:


### PR DESCRIPTION
## Summary
- handle opposite rules correctly when starting cell is fixed

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_684692a2ef908328b1f2d4dcb8117abc