### PR TITLE
Fix equal rule key bug

### DIFF
--- a/core.py
+++ b/core.py
@@ -190,7 +190,7 @@ class TangoBoard:
             if cell in eq_rule:
                 cell_eq = eq_rule.copy()
                 cell_eq.remove(cell)
-                result['equal': cell_eq]
+                result['equal'] = cell_eq
                 break
         return result
 


### PR DESCRIPTION
## Summary
- store cell associated with equal rules when retrieving them

## Testing
- `python -m py_compile core.py`


------
https://chatgpt.com/codex/tasks/task_b_6846930968948328a9270964d084925a