### PR TITLE
Fix equal rule storage in get_cell_rule

### DIFF
--- a/core.py
+++ b/core.py
@@ -190,7 +190,7 @@ class TangoBoard:
             if cell in eq_rule:
                 cell_eq = eq_rule.copy()
                 cell_eq.remove(cell)
-                result['equal': cell_eq]
+                result['equal'] = cell_eq
                 break
         return result
 


### PR DESCRIPTION
## Summary
- fix syntax error in `TangoBoard.get_cell_rule`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684692e441cc8328b749138b2f5da1d1