### PR TITLE
Fix opposite rule propagation

### DIFF
--- a/core.py
+++ b/core.py
@@ -88,7 +88,7 @@ class TangoBoard:
         else:
             self.set_opp_rule(x, y, x_2, y_2)
             if (x, y) in self.fixed_cells:
-                new_fixed_cell = self.apply_equal_rule(x, y)
+                new_fixed_cell = self.apply_opp_rule(x, y)
 
         
         if new_fixed_cell:


### PR DESCRIPTION
## Summary
- fix TangoBoard to propagate `opposite` rules correctly when the starting cell is fixed

## Testing
- `python -m py_compile core.py`

------
https://chatgpt.com/codex/tasks/task_b_684692b38a488328b0a668b09c17ae9e